### PR TITLE
Google redirects

### DIFF
--- a/src/components/PageWrapper/PageWrapper.jsx
+++ b/src/components/PageWrapper/PageWrapper.jsx
@@ -9,6 +9,16 @@ const PageWrapper = ({ pageTitle, children, className }) => {
   const { theme } = useContext(ThemeContext)
   const { pathname } = useLocation()
 
+  // ensures legacy redirects from google display page content correctly
+  useEffect(() => {
+    // if window.location.href ends in a slash, remove it
+    if (window.location.href.endsWith('/') && pathname !== '/') {
+      // remove ending slash from window.location.href and update the history
+      window.location.href = window.location.href.slice(0, -1)
+      window.history.replaceState(null, '', newUrl)
+    }
+  }, [pathname])
+
   useEffect(() => {
     window.scrollTo(top);
   }, [pathname])

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -11,6 +11,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
       <BrowserRouter>
         <Routes>
           <Route path='/' element={<GeneralLanding />} />
+          <Route path='/author/*' element={<Navigate to='/author' />} />
           <Route path='/author' element={<AuthorLanding />} />
           <Route path='/books/*' element={<Navigate to='/books' />} />
           <Route path='/books' element={<BooksLanding />} />

--- a/src/pages/Landing/GeneralLanding.jsx
+++ b/src/pages/Landing/GeneralLanding.jsx
@@ -69,7 +69,7 @@ const GeneralLanding = ({ pageNotFound }) => {
           </div>
           <h3>But we couldn't find the page you were looking for...</h3>
           <p>It might have been moved as part of a recent site migration.</p>
-          <p><Link to='/'>homepage</Link> | <Link to='mailto:campbell.ryan.r@gmail.com'>contact</Link></p>
+          <p><Link to='/'>homepage</Link> | <Link to='/contact'>contact</Link></p>
         </div>
       </ReactModal>
     </PageWrapper>


### PR DESCRIPTION
Resolves issues related to referrals from Google that cause URLs to end with `/` and the page view to subsequently fail to load images. This PR looks at the URL and, if it ends in `/`, removes it from the URL and then redirects to ensure images load as expected.