### PR TITLE
fix: redirect rrcampbellwrites.com visitors to ryanrcampbell.com domain

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { GeneralLanding, AuthorLanding, GeneralAbout, TechLanding, BooksLanding, BlogLanding, BlogPost, PodcastLanding, PodcastEpisode, ContactPage } from './pages/index.js'
+import { GeneralLanding, AuthorLanding, GeneralAbout, TechLanding, BooksLanding, PodcastLanding, PodcastEpisode, ContactPage } from './pages/index.js'
 import { Navigate, BrowserRouter, Routes, Route } from 'react-router-dom'
 import { SubstackRedirect } from './components/index.js'
 import './App.css'
 import { ThemeProvider } from './Theme.jsx'
+
+// see if rrcampbellwrites.com is the domain, if so, redirect to ryanrcampbell.com
+if (window.location.hostname === 'rrcampbellwrites.com') window.location.replace('https://ryanrcampbell.com' + window.location.pathname + window.location.search + window.location.hash)
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
Rather than let readers browse at rrcampbellwrites.com, this updates the URL to the ryanrcampbell.com hostname.